### PR TITLE
Fix #2

### DIFF
--- a/data/trek/loot_tables/fab_external.json
+++ b/data/trek/loot_tables/fab_external.json
@@ -6,10 +6,15 @@
 			"conditions": [
 				{
 					"condition": "random_chance",
-					"chance": 0.005
+					"chance": 0.0025
 				}
 			],
 			"entries": [
+				{
+					"type": "loot_table",
+					"name": "minecraft:gameplay/fishing/junk",
+					"weight": 500
+				},
 				{
 					"type": "item",
 					"name": "minecraft:golden_apple",

--- a/data/trek/loot_tables/fab_internal.json
+++ b/data/trek/loot_tables/fab_internal.json
@@ -6,7 +6,7 @@
 			"conditions": [
 				{
 					"condition": "random_chance",
-					"chance": 0.0075
+					"chance": 0.0025
 				}
 			],
 			"entries": [
@@ -65,27 +65,27 @@
 				{
 					"type": "item",
 					"name": "minecraft:diamond_helmet",
-					"weight": 5
+					"weight": 3
 				},
 				{
 					"type": "item",
 					"name": "minecraft:diamond_chestplate",
-					"weight": 5
+					"weight": 3
 				},
 				{
 					"type": "item",
 					"name": "minecraft:diamond_leggings",
-					"weight": 5
+					"weight": 3
 				},
 				{
 					"type": "item",
 					"name": "minecraft:diamond_boots",
-					"weight": 5
+					"weight": 3
 				},
 				{
 					"type": "item",
 					"name": "minecraft:diamond_sword",
-					"weight": 5
+					"weight": 3
 				},
 				{
 					"type": "item",


### PR DESCRIPTION
This changes the rates of the fabricators so that you can expect an item to spawn every 20 seconds, on average. This is down from around six seconds.

The external fabricator now produces [fishing junk](https://minecraft.gamepedia.com/Fishing#Junk_and_treasure), with a high weight. I figure it's pretty junky as far as junk goes, and balances out the potions and gapps you receive.

I also decreased the probability of diamond gear spawning.

I did not decrease the rate of the shield repair items spawning, I'm going to decrease the amount they heal the ship by in a separate PR.


It might be worth considering adding more maximum rolls to slightly counter the effect of the dramatically decreased spawn rates.