### PR TITLE
Debuff shield fuel

### DIFF
--- a/data/trek/functions/shields/collector_process.mcfunction
+++ b/data/trek/functions/shields/collector_process.mcfunction
@@ -1,5 +1,5 @@
 # Process hopper minecarts used to collect shield fuel
 
-execute if score @e[tag=trekShip,limit=1,sort=nearest] trekShieldHealth matches ..99 if data entity @s Items[{Slot:0b,Count:64b}] run scoreboard players add @e[tag=trekShip,limit=1,sort=nearest] trekShieldHealth 20
+execute if score @e[tag=trekShip,limit=1,sort=nearest] trekShieldHealth matches ..99 if data entity @s Items[{Slot:0b,Count:64b}] run scoreboard players add @e[tag=trekShip,limit=1,sort=nearest] trekShieldHealth 10
 scoreboard players set @e[tag=trekShip,scores={trekShieldHealth=100..}] trekShieldHealth 100 
 execute if score @e[tag=trekShip,limit=1,sort=nearest] trekShieldHealth matches ..99 if data entity @s Items[{Slot:0b,Count:64b}] run data modify entity @s Items[{Slot:0b,Count:64b}].Count set value 63b


### PR DESCRIPTION
This cuts the healing done by shield fuel in half.

It might be worth considering decreasing the phaser damage to the shields, too.